### PR TITLE
Implement DetermineResult and GetGameResult

### DIFF
--- a/Includes/Baba/Enums/Game.h
+++ b/Includes/Baba/Enums/Game.h
@@ -27,7 +27,6 @@ enum class GameStep
 enum class GameResult
 {
     INVALID,
-    NONE,
     WIN,
     DEFEAT,
     COUNT,

--- a/Includes/Baba/Enums/Game.h
+++ b/Includes/Baba/Enums/Game.h
@@ -1,0 +1,37 @@
+// Copyright(c) 2019 Hyeonsu Kim
+
+#ifndef BABA_ENUMS_GAME_H
+#define BABA_ENUMS_GAME_H
+
+namespace Baba
+{
+//!
+//! \brief Game steps
+//!
+enum class GameStep
+{
+    INVALID,
+    START_BEGIN,
+    START_LOAD_MAP,
+    MAIN_INIT,
+    MAIN_PARSE_RULES,
+    MAIN_APPLY_RULES,
+    MAIN_DETERMINE_RESULT,
+    MAIN_WAIT_ACTION,
+    MAIN_DO_ACTION,
+    END_WIN,
+    END_DEFEAT,
+    COUNT,
+};
+
+enum class GameResult
+{
+    INVALID,
+    NONE,
+    WIN,
+    DEFEAT,
+    COUNT,
+}
+}  // namespace Baba
+
+#endif  // BABA_ENUMS_GAME_H

--- a/Includes/Baba/Enums/Game.h
+++ b/Includes/Baba/Enums/Game.h
@@ -31,7 +31,7 @@ enum class GameResult
     WIN,
     DEFEAT,
     COUNT,
-}
+};
 }  // namespace Baba
 
 #endif  // BABA_ENUMS_GAME_H

--- a/Includes/Baba/Game/Game.h
+++ b/Includes/Baba/Game/Game.h
@@ -3,6 +3,7 @@
 #ifndef BABA_GAME_H
 #define BABA_GAME_H
 
+#include <Baba/Enums/Game.h>
 #include <Baba/Game/Object.h>
 #include <Baba/Rules/Rules.h>
 
@@ -99,11 +100,21 @@ class Game final
     //! Parse rules
     void ParseRules();
 
+    //! Determine game result
+    void DetermineResult();
+
+    //! Get game result;
+    //! \return GameResult
+    GameResult GetGameResult() const;
+
     Rules gameRules;
+
  private:
     std::size_t width_, height_;
     Object::Arr objects_;
     std::vector<Object::Arr> map_;
+    GameResult gameResult_ = GameResult::INVALID;
+    GameStep nowStep_ = GameStep::INVALID;
 };
 }  // namespace Baba
 

--- a/Sources/Baba/Game/Game.cc
+++ b/Sources/Baba/Game/Game.cc
@@ -298,7 +298,7 @@ void Game::DetermineResult()
         }
     }
 
-    gameResult_ = GameResult::NONE;
+    gameResult_ = GameResult::INVALID;
 }
 
 GameResult Game::GetGameResult() const

--- a/Sources/Baba/Game/Game.cc
+++ b/Sources/Baba/Game/Game.cc
@@ -1,6 +1,7 @@
 // Copyright(c) 2019 Junyeong Park, Hyeonsu Kim
 
 #include <Baba/Common/Utils.h>
+#include <Baba/Enums/Game.h>
 #include <Baba/Game/Game.h>
 #include <Baba/Rules/Effects.h>
 #include <Baba/Rules/Rule.h>
@@ -271,5 +272,37 @@ void Game::ParseRules()
             }
         }
     }
+}
+
+void Game::DetermineResult()
+{
+    auto targets = FindObjectsByProperty(EffectType::YOU);
+    
+    if (targets.empty())
+    {
+        gameResult_ = GameResult::DEFEAT;
+        return;
+    }
+
+    for (auto& target : targets)
+    {
+        auto objs = FindObjectsByPosition(*target);
+
+        for (auto& obj : objs)
+        {
+            if (obj->GetEffects().test(static_cast<std::size_t>(EffectType::WIN)))
+            {
+                gameResult_ = GameResult::WIN;
+                return;
+            }
+        }
+    }
+
+    gameResult_ = GameResult::NONE;
+}
+
+GameResult Game::GetGameResult() const
+{
+    return gameResult_;
 }
 }  // namespace Baba

--- a/Sources/Baba/Rules/Effects.cc
+++ b/Sources/Baba/Rules/Effects.cc
@@ -52,17 +52,6 @@ void Effects::ImplementNonBlockEffects()
     effects.emplace(EffectType::WIN, WinEffect);
 
     // ----------------------------------------------------------------------
-    // STOP
-    // If a YOU object contacts this object, the level is won.
-    // ----------------------------------------------------------------------
-    auto StopEffect = [](Game& game, Object& target, const Rule& rule) {
-        (void)game;
-        (void)target;
-        (void)rule;
-    };
-    effects.emplace(EffectType::STOP, StopEffect);
-
-    // ----------------------------------------------------------------------
     // MELT
     // Enchant target with MELT.
     // ----------------------------------------------------------------------

--- a/Sources/Baba/Rules/Effects.cc
+++ b/Sources/Baba/Rules/Effects.cc
@@ -30,6 +30,39 @@ void Effects::ImplementBlockEffects()
 void Effects::ImplementNonBlockEffects()
 {
     // ----------------------------------------------------------------------
+    // YOU
+    // The player can control this object
+    // ----------------------------------------------------------------------
+    auto YouEffect = [](Game& game, Object& target, const Rule& rule) {
+        (void)game;
+        (void)target;
+        (void)rule;
+    };
+    effects.emplace(EffectType::YOU, YouEffect);
+
+    // ----------------------------------------------------------------------
+    // WIN
+    // If a YOU object contacts this object, the level is won.
+    // ----------------------------------------------------------------------
+    auto WinEffect = [](Game& game, Object& target, const Rule& rule) {
+        (void)game;
+        (void)target;
+        (void)rule;
+    };
+    effects.emplace(EffectType::WIN, WinEffect);
+
+    // ----------------------------------------------------------------------
+    // STOP
+    // If a YOU object contacts this object, the level is won.
+    // ----------------------------------------------------------------------
+    auto StopEffect = [](Game& game, Object& target, const Rule& rule) {
+        (void)game;
+        (void)target;
+        (void)rule;
+    };
+    effects.emplace(EffectType::STOP, StopEffect);
+
+    // ----------------------------------------------------------------------
     // MELT
     // Enchant target with MELT.
     // ----------------------------------------------------------------------

--- a/UnitTest/Game/GameTest.cc
+++ b/UnitTest/Game/GameTest.cc
@@ -251,7 +251,7 @@ TEST(GameTest, DetermineResult_DEFEAT)
     EXPECT_EQ(game.GetGameResult(), GameResult::DEFEAT);
 }
 
-TEST(GameTest, DetermineResult_NONE)
+TEST(GameTest, DetermineResult_INVALID)
 {
     Game game(10, 10);
 
@@ -273,5 +273,5 @@ TEST(GameTest, DetermineResult_NONE)
     game.ApplyRules();
     game.DetermineResult();
 
-    EXPECT_EQ(game.GetGameResult(), GameResult::NONE);
+    EXPECT_EQ(game.GetGameResult(), GameResult::INVALID);
 }

--- a/UnitTest/Game/GameTest.cc
+++ b/UnitTest/Game/GameTest.cc
@@ -199,3 +199,79 @@ TEST(GameTest, ParseRules_Cross)
     EXPECT_EQ(game.At(1, 1).at(0)->GetType(), ObjectType::KEKE);
     EXPECT_TRUE(game.FindObjectsByType(ObjectType::BABA).empty());
 }
+
+TEST(GameTest, DetermineResult_WIN)
+{
+    Game game(10, 10);
+
+    game.Put(1, 1).SetType(ObjectType::BABA).SetEffectType(EffectType::BABA);
+    game.Put(1, 1).SetType(ObjectType::FLAG).SetEffectType(EffectType::FLAG);
+    game.Put(5, 5)
+        .SetType(ObjectType::TEXT_BABA)
+        .SetEffectType(EffectType::BABA)
+        .SetEffect(EffectType::WORD);
+    game.Put(5, 6)
+        .SetType(ObjectType::TEXT_IS)
+        .SetEffectType(EffectType::IS)
+        .SetEffect(EffectType::WORD);
+    game.Put(5, 7)
+        .SetType(ObjectType::TEXT_YOU)
+        .SetEffectType(EffectType::YOU)
+        .SetEffect(EffectType::WORD);
+    game.Put(6, 5)
+        .SetType(ObjectType::TEXT_FLAG)
+        .SetEffectType(EffectType::FLAG)
+        .SetEffect(EffectType::WORD);
+    game.Put(6, 6)
+        .SetType(ObjectType::TEXT_IS)
+        .SetEffectType(EffectType::IS)
+        .SetEffect(EffectType::WORD);
+    game.Put(6, 7)
+        .SetType(ObjectType::TEXT_WIN)
+        .SetEffectType(EffectType::WIN)
+        .SetEffect(EffectType::WORD);
+
+    game.ParseRules();
+    game.ApplyRules();
+    game.DetermineResult();
+
+    EXPECT_EQ(game.GetGameResult(), GameResult::WIN);
+}
+
+TEST(GameTest, DetermineResult_DEFEAT)
+{
+    Game game(10, 10);
+
+    game.Put(1, 1).SetType(ObjectType::BABA).SetEffectType(EffectType::BABA);
+
+    game.ParseRules();
+    game.ApplyRules();
+    game.DetermineResult();
+
+    EXPECT_EQ(game.GetGameResult(), GameResult::DEFEAT);
+}
+
+TEST(GameTest, DetermineResult_NONE)
+{
+    Game game(10, 10);
+
+    game.Put(1, 1).SetType(ObjectType::BABA).SetEffectType(EffectType::BABA);
+    game.Put(5, 5)
+        .SetType(ObjectType::TEXT_BABA)
+        .SetEffectType(EffectType::BABA)
+        .SetEffect(EffectType::WORD);
+    game.Put(5, 6)
+        .SetType(ObjectType::TEXT_IS)
+        .SetEffectType(EffectType::IS)
+        .SetEffect(EffectType::WORD);
+    game.Put(5, 7)
+        .SetType(ObjectType::TEXT_YOU)
+        .SetEffectType(EffectType::YOU)
+        .SetEffect(EffectType::WORD);
+
+    game.ParseRules();
+    game.ApplyRules();
+    game.DetermineResult();
+
+    EXPECT_EQ(game.GetGameResult(), GameResult::NONE);
+}

--- a/UnitTest/Rules/EffectTest.cc
+++ b/UnitTest/Rules/EffectTest.cc
@@ -43,11 +43,6 @@ TEST(EffectTest, WIN)
     // Do nothing
 }
 
-TEST(EffectTest, STOP)
-{
-    // Not implemented yet
-}
-
 TEST(EffectTest, MELT)
 {
     Game game(5, 5);

--- a/UnitTest/Rules/EffectTest.cc
+++ b/UnitTest/Rules/EffectTest.cc
@@ -33,6 +33,21 @@ TEST(EffectTest, BABA)
     EXPECT_EQ(*game.FindObjectsByType(ObjectType::STAR).at(0), obj2);
 }
 
+TEST(EffectTest, YOU)
+{
+    // Not implemented yet
+}
+
+TEST(EffectTest, WIN)
+{
+    // Do nothing
+}
+
+TEST(EffectTest, STOP)
+{
+    // Not implemented yet
+}
+
 TEST(EffectTest, MELT)
 {
     Game game(5, 5);


### PR DESCRIPTION
This revision includes:
- Implement `DetermineResult` and `GetGameResult`
- Add `GameStep` `GameResult`. `GameStep` is not currently used, but will be used later.
- Implement `WIN`
- Add `YOU` and `STOP`. They will be implemented later.